### PR TITLE
Change Kill command to work when not host

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -214,7 +214,7 @@ namespace UnwantedCompany
                 {
                     Application.OpenURL("https://steamcommunity.com/profiles/" + Settings.Instance.selectedPlayer.playerSteamId);
                 }
-                if (GUILayout.Button("Kill (Host)"))
+                if (GUILayout.Button("Kill"))
                 {
                     //Vector3 vector3 = new Vector3(1f, 1f, 1f);
                     //Settings.Instance.selectedPlayer.KillPlayer(vector3, true, CauseOfDeath.Suffocation, 0);

--- a/Main.cs
+++ b/Main.cs
@@ -216,8 +216,9 @@ namespace UnwantedCompany
                 }
                 if (GUILayout.Button("Kill (Host)"))
                 {
-                    Vector3 vector3 = new Vector3(1f, 1f, 1f);
-                    Settings.Instance.selectedPlayer.KillPlayer(vector3, true, CauseOfDeath.Suffocation, 0);
+                    //Vector3 vector3 = new Vector3(1f, 1f, 1f);
+                    //Settings.Instance.selectedPlayer.KillPlayer(vector3, true, CauseOfDeath.Suffocation, 0);
+                    Settings.Instance.selectedPlayer.DamagePlayerFromOtherClientServerRpc(1000, new Vector3(0f, 0f, 0f), 0);
                 }
                 if (GUILayout.Button("Heal (Host)"))
                 {


### PR DESCRIPTION
You can now kill any player on the server, without being host, from any distance. Your client will deal 1000 shovel damage, and they'll have no idea how they died. Very fun in random servers. 

Old: KillPlayer()

New: DamagePlayerFromOtherClientServerRpc()